### PR TITLE
Lagt dit Content-Type, för RestSharp

### DIFF
--- a/GDB.M2M.Service/HttpClients/RestSharpFileUploader.cs
+++ b/GDB.M2M.Service/HttpClients/RestSharpFileUploader.cs
@@ -59,6 +59,7 @@ namespace GDB.M2M.Service.HttpClients
 
             var url = client.BuildUri(request);
             _logger.LogInformation($"Posting file to: {url}");
+            request.AddHeader("Content-Type", "multipart/mixed");
             var response = await client.ExecutePostAsync<FileUploadResponse>(request);
 
             if (response.StatusCode == HttpStatusCode.OK && response.Data != null)


### PR DESCRIPTION
RestSharpKlienten slutade fungera efterr uppgraderingen av indataportalen till .net5. 
Content-Type behöver därför läggas till innan anropen görs.